### PR TITLE
 Add per-slice UDP interconnect statistics

### DIFF
--- a/protos/yagpcc_metrics.proto
+++ b/protos/yagpcc_metrics.proto
@@ -42,6 +42,11 @@ message AdditionalQueryInfo {
     int64 slice_id                        = 3;
 }
 
+message AdditionalQueryStat {
+    string error_message                  = 1;
+    repeated int64 slices                 = 2;
+}
+
 enum PlanGenerator
 {
     PLAN_GENERATOR_UNSPECIFIED = 0;
@@ -96,6 +101,56 @@ message NetworkStat {
     uint32 chunks = 3;
 }
 
+message InterconnectStat {
+    // Receive queue size sum when main thread is trying to get a packet
+    uint64 total_recv_queue_size = 1;
+    // Counting times when computing total_recv_queue_size
+    uint64 recv_queue_size_counting_time = 2;
+
+    // The capacity sum when packets are tried to be sent
+    uint64 total_capacity = 3;
+    // Counting times used to compute total_capacity
+    uint64 capacity_counting_time = 4;
+
+    // Total buffers available when sending packets
+    uint64 total_buffers = 5;
+    // Counting times when compute total_buffers
+    uint64 buffer_counting_time = 6;
+
+    // The number of active connections
+    uint64 active_connections_num = 7;
+
+    // The number of packet retransmits
+    int64 retransmits = 8;
+
+    // The number of cached future packets
+    int64 startup_cached_pkt_num = 9;
+
+    // The number of mismatched packets received
+    int64 mismatch_num = 10;
+
+    // The number of crc errors
+    int64 crc_errors = 11;
+
+    // The number of packets sent by sender
+    int64 snd_pkt_num = 12;
+
+    // The number of packets received by receiver
+    int64 recv_pkt_num = 13;
+
+    // Disordered packet number
+    int64 disordered_pkt_num = 14;
+
+    // Duplicate packet number
+    int64 duplicated_pkt_num = 15;
+
+    // The number of Acks received
+    int64 recv_ack_num = 16;
+
+    // The number of status query messages sent
+    int64 status_query_msg_num = 17;
+}
+
 message MetricInstrumentation {
     uint64  ntuples     = 1;    /* Total tuples produced */
     uint64  nloops      = 2;    /* # of run cycles for this node */
@@ -120,6 +175,7 @@ message MetricInstrumentation {
     double  startup_time       = 21; /* real query startup time (planning + queue time) */
     uint64  inherited_calls    = 22; /* the number of executed sub-queries */
     double  inherited_time     = 23; /* total time spend on inherited execution */
+    InterconnectStat interconnect = 24;
 }
 
 message SpillInfo {

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -7,7 +7,10 @@
 #define typeid __typeid
 extern "C" {
 #include "utils/metrics_utils.h"
+#include "cdb/ml_ipc.h"
+#ifdef IC_TEARDOWN_HOOK
 #include "cdb/ic_udpifc.h"
+#endif
 }
 #undef typeid
 
@@ -59,6 +62,8 @@ private:
   int nesting_level = 0;
   int64_t nested_calls = 0;
   double nested_timing = 0;
+#ifdef IC_TEARDOWN_HOOK
   ICStatistics ic_statistics;
+#endif
   std::unordered_map<std::pair<int, int>, QueryItem, pair_hash> query_msgs;
 };

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -4,9 +4,12 @@
 #include <unordered_map>
 #include <string>
 
+#define typeid __typeid
 extern "C" {
 #include "utils/metrics_utils.h"
+#include "cdb/ic_udpifc.h"
 }
+#undef typeid
 
 class UDSConnector;
 struct QueryDesc;
@@ -20,6 +23,7 @@ public:
   void executor_after_start(QueryDesc *query_desc, int eflags);
   void executor_end(QueryDesc *query_desc);
   void query_metrics_collect(QueryMetricsStatus status, void *arg);
+  void ic_metrics_collect();
   void incr_depth() { nesting_level++; }
   void decr_depth() { nesting_level--; }
   EventSender();
@@ -55,5 +59,6 @@ private:
   int nesting_level = 0;
   int64_t nested_calls = 0;
   double nested_timing = 0;
+  ICStatistics ic_statistics;
   std::unordered_map<std::pair<int, int>, QueryItem, pair_hash> query_msgs;
 };

--- a/src/ProtoUtils.cpp
+++ b/src/ProtoUtils.cpp
@@ -10,7 +10,10 @@ extern "C" {
 #include "access/hash.h"
 #include "cdb/cdbinterconnect.h"
 #include "cdb/cdbvars.h"
+#include "cdb/ml_ipc.h"
+#ifdef IC_TEARDOWN_HOOK
 #include "cdb/ic_udpifc.h"
+#endif
 #include "gpmon/gpmon.h"
 #include "utils/workfile_mgr.h"
 
@@ -182,6 +185,7 @@ void set_gp_metrics(yagpcc::GPMetrics *metrics, QueryDesc *query_desc,
 
 void set_ic_stats(yagpcc::MetricInstrumentation *metrics,
                   const ICStatistics *ic_statistics) {
+#ifdef IC_TEARDOWN_HOOK
   UPDATE_IC_STATS(total_recv_queue_size, totalRecvQueueSize);
   UPDATE_IC_STATS(recv_queue_size_counting_time, recvQueueSizeCountingTime);
   UPDATE_IC_STATS(total_capacity, totalCapacity);
@@ -199,6 +203,7 @@ void set_ic_stats(yagpcc::MetricInstrumentation *metrics,
   UPDATE_IC_STATS(duplicated_pkt_num, duplicatedPktNum);
   UPDATE_IC_STATS(recv_ack_num, recvAckNum);
   UPDATE_IC_STATS(status_query_msg_num, statusQueryMsgNum);
+#endif
 }
 
 yagpcc::SetQueryReq create_query_req(yagpcc::QueryStatus status) {

--- a/src/ProtoUtils.cpp
+++ b/src/ProtoUtils.cpp
@@ -10,6 +10,7 @@ extern "C" {
 #include "access/hash.h"
 #include "cdb/cdbinterconnect.h"
 #include "cdb/cdbvars.h"
+#include "cdb/ic_udpifc.h"
 #include "gpmon/gpmon.h"
 #include "utils/workfile_mgr.h"
 
@@ -169,6 +170,35 @@ void set_gp_metrics(yagpcc::GPMetrics *metrics, QueryDesc *query_desc,
       WorkfileTotalFilesCreated() - metrics->mutable_spill()->filecount());
   metrics->mutable_spill()->set_totalbytes(
       WorkfileTotalBytesWritten() - metrics->mutable_spill()->totalbytes());
+}
+
+#define UPDATE_IC_STATS(proto_name, stat_name)                                 \
+  metrics->mutable_interconnect()->set_##proto_name(                           \
+      ic_statistics->stat_name -                                               \
+      metrics->mutable_interconnect()->proto_name());                          \
+  Assert(metrics->mutable_interconnect()->proto_name() >= 0 &&                 \
+         metrics->mutable_interconnect()->proto_name() <=                      \
+             ic_statistics->stat_name)
+
+void set_ic_stats(yagpcc::MetricInstrumentation *metrics,
+                  const ICStatistics *ic_statistics) {
+  UPDATE_IC_STATS(total_recv_queue_size, totalRecvQueueSize);
+  UPDATE_IC_STATS(recv_queue_size_counting_time, recvQueueSizeCountingTime);
+  UPDATE_IC_STATS(total_capacity, totalCapacity);
+  UPDATE_IC_STATS(capacity_counting_time, capacityCountingTime);
+  UPDATE_IC_STATS(total_buffers, totalBuffers);
+  UPDATE_IC_STATS(buffer_counting_time, bufferCountingTime);
+  UPDATE_IC_STATS(active_connections_num, activeConnectionsNum);
+  UPDATE_IC_STATS(retransmits, retransmits);
+  UPDATE_IC_STATS(startup_cached_pkt_num, startupCachedPktNum);
+  UPDATE_IC_STATS(mismatch_num, mismatchNum);
+  UPDATE_IC_STATS(crc_errors, crcErrors);
+  UPDATE_IC_STATS(snd_pkt_num, sndPktNum);
+  UPDATE_IC_STATS(recv_pkt_num, recvPktNum);
+  UPDATE_IC_STATS(disordered_pkt_num, disorderedPktNum);
+  UPDATE_IC_STATS(duplicated_pkt_num, duplicatedPktNum);
+  UPDATE_IC_STATS(recv_ack_num, recvAckNum);
+  UPDATE_IC_STATS(status_query_msg_num, statusQueryMsgNum);
 }
 
 yagpcc::SetQueryReq create_query_req(yagpcc::QueryStatus status) {

--- a/src/ProtoUtils.h
+++ b/src/ProtoUtils.h
@@ -1,6 +1,7 @@
 #include "protos/yagpcc_set_service.pb.h"
 
 struct QueryDesc;
+struct ICStatistics;
 
 google::protobuf::Timestamp current_ts();
 void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc);
@@ -12,5 +13,7 @@ void set_qi_slice_id(yagpcc::SetQueryReq *req);
 void set_qi_error_message(yagpcc::SetQueryReq *req);
 void set_gp_metrics(yagpcc::GPMetrics *metrics, QueryDesc *query_desc,
                     int nested_calls, double nested_time);
+void set_ic_stats(yagpcc::MetricInstrumentation *metrics,
+                  const ICStatistics *ic_statistics);
 yagpcc::SetQueryReq create_query_req(yagpcc::QueryStatus status);
 double protots_to_double(const google::protobuf::Timestamp &ts);


### PR DESCRIPTION
This feature relies on this [commit](https://github.com/open-gpdb/gpdb/commit/a95c9387245029f254198ac553841e01d1b910cd) in gpdb, which adds ic teardown hook and a function to retrieve interconnect statistics from running backend. If this commit is not present, hooks collector does not collect any IC statistics.

Otherwise, this PR allows to collect per-slice interconnect statistics for finished queries.