### PR TITLE
fix: propagate ignored users on update

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -6,7 +6,6 @@
 
 extern "C" {
 #include "postgres.h"
-#include "utils/builtins.h"
 #include "utils/guc.h"
 }
 
@@ -17,39 +16,11 @@ static bool guc_enable_collector = true;
 static bool guc_report_nested_queries = true;
 static char *guc_ignored_users = nullptr;
 static int guc_max_text_size = 1024; // in KB
-static std::unique_ptr<std::unordered_set<std::string>> ignored_users = nullptr;
+std::unique_ptr<std::unordered_set<std::string>> ignored_users_set = nullptr;
+bool ignored_users_guc_dirty = false;
 
-extern "C" void update_ignored_users(const char *new_guc_ignored_users) {
-  auto new_ignored_users = std::make_unique<std::unordered_set<std::string>>();
-  if (new_guc_ignored_users != nullptr && new_guc_ignored_users[0] != '\0') {
-    /* Need a modifiable copy of string */
-    char *rawstring = pstrdup(new_guc_ignored_users);
-    List *elemlist;
-    ListCell *l;
-
-    /* Parse string into list of identifiers */
-    if (!SplitIdentifierString(rawstring, ',', &elemlist)) {
-      /* syntax error in list */
-      pfree(rawstring);
-      list_free(elemlist);
-      ereport(
-          LOG,
-          (errcode(ERRCODE_SYNTAX_ERROR),
-           errmsg(
-               "invalid list syntax in parameter yagpcc.ignored_users_list")));
-      return;
-    }
-    foreach (l, elemlist) {
-      new_ignored_users->insert((char *)lfirst(l));
-    }
-    pfree(rawstring);
-    list_free(elemlist);
-  }
-  ignored_users = std::move(new_ignored_users);
-}
-
-static void assign_ignored_users_hook(const char *newval, void *extra) {
-  update_ignored_users(newval);
+static void assign_ignored_users_hook(const char *, void *) {
+  ignored_users_guc_dirty = true;
 }
 
 void Config::init() {
@@ -96,11 +67,12 @@ bool Config::enable_analyze() { return guc_enable_analyze; }
 bool Config::enable_cdbstats() { return guc_enable_cdbstats; }
 bool Config::enable_collector() { return guc_enable_collector; }
 bool Config::report_nested_queries() { return guc_report_nested_queries; }
+const char *Config::ignored_users() { return guc_ignored_users; }
 size_t Config::max_text_size() { return guc_max_text_size * 1024; }
 
 bool Config::filter_user(const std::string *username) {
-  if (!username || !ignored_users) {
+  if (!username || !ignored_users_set) {
     return true;
   }
-  return ignored_users->find(*username) != ignored_users->end();
+  return ignored_users_set->find(*username) != ignored_users_set->end();
 }

--- a/src/Config.h
+++ b/src/Config.h
@@ -11,5 +11,6 @@ public:
   static bool enable_collector();
   static bool filter_user(const std::string *username);
   static bool report_nested_queries();
+  static const char *ignored_users();
   static size_t max_text_size();
 };

--- a/src/Config.h
+++ b/src/Config.h
@@ -11,6 +11,6 @@ public:
   static bool enable_collector();
   static bool filter_user(const std::string *username);
   static bool report_nested_queries();
-  static const char *ignored_users();
   static size_t max_text_size();
+  static void sync();
 };

--- a/src/EventSender.cpp
+++ b/src/EventSender.cpp
@@ -262,7 +262,7 @@ void EventSender::ic_metrics_collect() {
 }
 
 EventSender::EventSender() {
-  if (Config::enable_collector() && !Config::filter_user(get_user_name())) {
+  if (Config::enable_collector()) {
     try {
       connector = new UDSConnector();
     } catch (const std::exception &e) {

--- a/src/EventSender.cpp
+++ b/src/EventSender.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include "access/hash.h"
 #include "executor/executor.h"
 #include "utils/elog.h"
+#include "utils/builtins.h"
 
 #include "cdb/cdbdisp.h"
 #include "cdb/cdbexplain.h"
@@ -19,6 +20,9 @@ extern "C" {
 #include "EventSender.h"
 #include "PgUtils.h"
 #include "ProtoUtils.h"
+
+extern std::unique_ptr<std::unordered_set<std::string>> ignored_users_set;
+extern bool ignored_users_guc_dirty;
 
 void EventSender::query_metrics_collect(QueryMetricsStatus status, void *arg) {
   if (Gp_role != GP_ROLE_DISPATCH && Gp_role != GP_ROLE_EXECUTE) {
@@ -61,6 +65,10 @@ void EventSender::executor_before_start(QueryDesc *query_desc,
   if (is_top_level_query(query_desc, nesting_level)) {
     nested_timing = 0;
     nested_calls = 0;
+  }
+  if (ignored_users_guc_dirty) {
+    update_ignored_users(Config::ignored_users());
+    ignored_users_guc_dirty = false;
   }
   if (!need_collect(query_desc, nesting_level)) {
     return;
@@ -345,6 +353,36 @@ void EventSender::update_nested_counters(QueryDesc *query_desc) {
               (errmsg("YAGPCC nested query text %s", query_desc->sourceText)));
     }
   }
+}
+
+void EventSender::update_ignored_users(const char *new_guc_ignored_users) {
+  auto new_ignored_users_set =
+      std::make_unique<std::unordered_set<std::string>>();
+  if (new_guc_ignored_users != nullptr && new_guc_ignored_users[0] != '\0') {
+    /* Need a modifiable copy of string */
+    char *rawstring = pstrdup(new_guc_ignored_users);
+    List *elemlist;
+    ListCell *l;
+
+    /* Parse string into list of identifiers */
+    if (!SplitIdentifierString(rawstring, ',', &elemlist)) {
+      /* syntax error in list */
+      pfree(rawstring);
+      list_free(elemlist);
+      ereport(
+          LOG,
+          (errcode(ERRCODE_SYNTAX_ERROR),
+           errmsg(
+               "invalid list syntax in parameter yagpcc.ignored_users_list")));
+      return;
+    }
+    foreach (l, elemlist) {
+      new_ignored_users_set->insert((char *)lfirst(l));
+    }
+    pfree(rawstring);
+    list_free(elemlist);
+  }
+  ignored_users_set = std::move(new_ignored_users_set);
 }
 
 EventSender::QueryItem::QueryItem(EventSender::QueryState st,

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -57,7 +57,6 @@ private:
   void collect_query_done(QueryDesc *query_desc, QueryMetricsStatus status);
   void cleanup_messages();
   void update_nested_counters(QueryDesc *query_desc);
-  void update_ignored_users(const char *new_guc_ignored_users);
 
   UDSConnector *connector = nullptr;
   int nesting_level = 0;

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -57,6 +57,7 @@ private:
   void collect_query_done(QueryDesc *query_desc, QueryMetricsStatus status);
   void cleanup_messages();
   void update_nested_counters(QueryDesc *query_desc);
+  void update_ignored_users(const char *new_guc_ignored_users);
 
   UDSConnector *connector = nullptr;
   int nesting_level = 0;


### PR DESCRIPTION
Two fixes were introduced:

* Removed `filter_user` when creating the connector. Previously, if `guc_ignored_users` initially ignored a user running the extension, the connector was not created. If later the user was removed from `guc_ignored_users`, the connector could not be created because it only starts with the extension and no other query stats could be collected because the connector was null.

* Since a superuser can change `guc_ignored_users`, we no longer cache ignored users for the entire extension duration. Instead, the cache updates whenever `guc_ignored_users` changes.