### PR TITLE
Alloc mem using postgres memory contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ OBJS			:=	$(PG_STAT_OBJS)						\
 					$(SRC_DIR)/UDSConnector.o			\
 					$(SRC_DIR)/EventSender.o 			\
 					$(SRC_DIR)/hook_wrappers.o		 	\
-					$(SRC_DIR)/yagp_hooks_collector.o
+					$(SRC_DIR)/yagp_hooks_collector.o   \
+					$(SRC_DIR)/PgMemUtils.o
 EXTRA_CLEAN     := $(GEN_DIR)
 DATA			:= $(wildcard sql/*--*.sql)
 EXTENSION		:= yagp_hooks_collector

--- a/src/EventSender.cpp
+++ b/src/EventSender.cpp
@@ -20,6 +20,8 @@ extern "C" {
 #include "PgUtils.h"
 #include "ProtoUtils.h"
 
+extern ContextUniquePtr backend_context;
+
 #define need_collect_analyze()                                                 \
   (Gp_role == GP_ROLE_DISPATCH && Config::min_analyze_time() >= 0 &&           \
    Config::enable_analyze())
@@ -305,10 +307,11 @@ void EventSender::analyze_stats_collect(QueryDesc *query_desc) {
   }
 }
 
-EventSender::EventSender() {
+EventSender::EventSender()
+    : query_msgs(backend_context->get_allocator<QueryMapAllocator>()) {
   if (Config::enable_collector()) {
     try {
-      connector = new UDSConnector();
+      connector = backend_context->pnew<UDSConnector>();
     } catch (const std::exception &e) {
       ereport(INFO, (errmsg("Unable to start query tracing %s", e.what())));
     }
@@ -319,7 +322,8 @@ EventSender::EventSender() {
 }
 
 EventSender::~EventSender() {
-  delete connector;
+  // The connector is cleaned automatically when the backend memory context gets
+  // deleted.
   for (auto iter = query_msgs.begin(); iter != query_msgs.end(); ++iter) {
     delete iter->second.message;
   }

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "PgMemUtils.h"
+
 #include <memory>
 #include <unordered_map>
 #include <string>
@@ -43,14 +45,6 @@ private:
     QueryItem(QueryState st, yagpcc::SetQueryReq *msg);
   };
 
-  struct pair_hash {
-    std::size_t operator()(const std::pair<int, int> &p) const {
-      auto h1 = std::hash<int>{}(p.first);
-      auto h2 = std::hash<int>{}(p.second);
-      return h1 ^ h2;
-    }
-  };
-
   void update_query_state(QueryDesc *query_desc, QueryItem *query,
                           QueryState new_state, bool success = true);
   QueryItem *get_query_message(QueryDesc *query_desc);
@@ -66,5 +60,18 @@ private:
 #ifdef IC_TEARDOWN_HOOK
   ICStatistics ic_statistics;
 #endif
-  std::unordered_map<std::pair<int, int>, QueryItem, pair_hash> query_msgs;
+  using QueryKey = std::pair<int, int>;
+  using QueryValue = QueryItem;
+  using QueryMapAllocator =
+      PallocZeroAllocator<std::pair<const QueryKey, QueryValue>>;
+  struct pair_hash {
+    std::size_t operator()(const QueryKey &p) const {
+      auto h1 = std::hash<int>{}(p.first);
+      auto h2 = std::hash<int>{}(p.second);
+      return h1 ^ h2;
+    }
+  };
+  std::unordered_map<QueryKey, QueryValue, pair_hash, std::equal_to<QueryKey>,
+                     QueryMapAllocator>
+      query_msgs;
 };

--- a/src/PgMemUtils.cpp
+++ b/src/PgMemUtils.cpp
@@ -1,0 +1,53 @@
+#include "PgMemUtils.h"
+
+ManagedMemContext::ManagedMemContext(MemoryContext parent, const char *name) {
+  context = AllocSetContextCreate(parent, name, ALLOCSET_DEFAULT_SIZES);
+  // Allocate the vector itself inside the context.
+  PallocZeroAllocator<DtorThunk> allocator(context);
+  void *vec_mem = MemoryContextAlloc(
+      context, sizeof(std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>));
+  dtor_thunks = new (vec_mem)
+      std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>(allocator);
+  // Register a callback so PG's MemoryContext Reset/Delete will call our
+  // destructors.
+  context_callback.func = ManagedMemContext::reset_callback;
+  context_callback.arg = this;
+  MemoryContextRegisterResetCallback(context, &context_callback);
+}
+
+ManagedMemContext::~ManagedMemContext() {
+  if (context) {
+    // This will trigger the reset_callback, which calls run_destructors.
+    // Note that callback is called before raw memory is freed.
+    MemoryContextDelete(context);
+  }
+}
+
+ContextUniquePtr ManagedMemContext::create(MemoryContext parent,
+                                           const char *name) {
+  void *mem = MemoryContextAllocZero(parent, sizeof(ManagedMemContext));
+  ManagedMemContext *obj = new (mem) ManagedMemContext(parent, name);
+  return ContextUniquePtr(obj);
+}
+
+void ManagedMemContext::run_destructors() {
+  // Call destructors in reverse order of construction.
+  for (auto it = dtor_thunks->rbegin(); it != dtor_thunks->rend(); ++it) {
+    (*it)();
+  }
+  // The vector's memory will be freed by the subsequent MemoryContext
+  // Reset/Delete, so we don't need to clear it here. Just call its own
+  // destructor.
+  dtor_thunks->~vector();
+}
+
+void ManagedMemContext::reset_callback(void *arg) {
+  static_cast<ManagedMemContext *>(arg)->run_destructors();
+}
+
+void PallocDeleter::operator()(ManagedMemContext *p) const {
+  if (p) {
+    p->~ManagedMemContext();
+    pfree(p);
+  }
+}

--- a/src/PgMemUtils.h
+++ b/src/PgMemUtils.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <new>
+#include <vector>
+#include <memory>
+#include <functional>
+
+extern "C" {
+#include "postgres.h"
+#include "utils/memutils.h"
+}
+
+template <typename T> struct PallocZeroAllocator {
+  using value_type = T;
+  MemoryContext context;
+
+  explicit PallocZeroAllocator(MemoryContext ctx) noexcept : context(ctx) {}
+
+  template <class U>
+  PallocZeroAllocator(const PallocZeroAllocator<U> &other) noexcept
+      : context(other.context) {}
+
+  template <typename U> struct rebind { using other = PallocZeroAllocator<U>; };
+
+  T *allocate(size_t n) {
+    return static_cast<T *>(MemoryContextAllocZero(context, n * sizeof(T)));
+  }
+
+  // Deallocation is a no-op because MemoryContext owns the memory.
+  void deallocate(T *, size_t) noexcept {}
+};
+
+template <class T, class U>
+bool operator==(const PallocZeroAllocator<T> &a,
+                const PallocZeroAllocator<U> &b) noexcept {
+  return a.context == b.context;
+}
+
+template <class T, class U>
+bool operator!=(const PallocZeroAllocator<T> &a,
+                const PallocZeroAllocator<U> &b) noexcept {
+  return !(a == b);
+}
+
+class ManagedMemContext;
+
+struct PallocDeleter {
+  void operator()(ManagedMemContext *p) const;
+};
+
+using ContextUniquePtr = std::unique_ptr<ManagedMemContext, PallocDeleter>;
+
+// Manages the lifetime of a PG MemoryContext and handles the
+// destruction of C++ objects allocated within it.
+class ManagedMemContext {
+  friend struct PallocDeleter;
+
+public:
+  using DtorThunk = std::function<void()>;
+
+  static ContextUniquePtr create(MemoryContext parent, const char *name);
+
+  ManagedMemContext(const ManagedMemContext &) = delete;
+  ManagedMemContext &operator=(const ManagedMemContext &) = delete;
+
+  // Constructs an object within the context.
+  // Its destructor will be called when the context is reset or destroyed.
+  template <typename T, typename... Args> T *pnew(Args &&...args) {
+    T *obj = new (allocate0<T>(sizeof(T))) T(std::forward<Args>(args)...);
+    // Register the destructor to be called on cleanup.
+    dtor_thunks->push_back([obj]() { obj->~T(); });
+    return obj;
+  }
+
+  template <typename T> PallocZeroAllocator<T> get_allocator() const {
+    return PallocZeroAllocator<T>(context);
+  }
+
+  MemoryContext get_context() const { return context; }
+
+  // Allocate raw, zero initialized memory within the context.
+  template <typename T = void> T *allocate0(size_t size) {
+    return static_cast<T *>(MemoryContextAllocZero(context, size));
+  }
+
+private:
+  ManagedMemContext(MemoryContext parent, const char *name);
+
+  // Calls MemoryContextDelete(), which first calls its callback - destructors
+  // in our case and then frees associated raw memory.
+  ~ManagedMemContext();
+
+  void run_destructors();
+
+  static void reset_callback(void *arg);
+
+  MemoryContext context;
+  MemoryContextCallback context_callback;
+  // Holds the destructors. It is itself allocated within the context.
+  std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>> *dtor_thunks = nullptr;
+};

--- a/src/hook_wrappers.cpp
+++ b/src/hook_wrappers.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "Config.h"
 #include "YagpStat.h"
 #include "EventSender.h"
+#include "PgMemUtils.h"
 #include "hook_wrappers.h"
 #include "stat_statements_parser/pg_stat_statements_ya_parser.h"
 
@@ -45,11 +46,14 @@ static void ya_ic_teardown_hook(ChunkTransportState *transportStates,
 static void ya_analyze_stats_collect_hook(QueryDesc *query_desc);
 #endif
 
+ContextUniquePtr backend_context;
+// Owned by the backend_context.
 static EventSender *sender = nullptr;
 
 static inline EventSender *get_sender() {
   if (!sender) {
-    sender = new EventSender();
+    Assert(backend_context != nullptr);
+    sender = backend_context->pnew<EventSender>();
   }
   return sender;
 }
@@ -85,6 +89,10 @@ void hooks_init() {
   analyze_stats_collect_hook = ya_analyze_stats_collect_hook;
 #endif
   stat_statements_parser_init();
+  if (backend_context == nullptr) {
+    backend_context =
+        ManagedMemContext::create(TopMemoryContext, "YaHooksBackendContext");
+  }
 }
 
 void hooks_deinit() {
@@ -100,10 +108,9 @@ void hooks_deinit() {
   analyze_stats_collect_hook = previous_analyze_stats_collect_hook;
 #endif
   stat_statements_parser_deinit();
-  if (sender) {
-    delete sender;
-  }
   YagpStat::deinit();
+  backend_context.reset();
+  sender = nullptr;
 }
 
 void ya_ExecutorStart_hook(QueryDesc *query_desc, int eflags) {


### PR DESCRIPTION
This pr replaces heap allocations with postgres memory context allocations (e.g., `palloc()` / `pfree()`).

All heap allocations in the extension fall into two groups based on their lifetimes:
1. Backend lifetime (`TopMemoryContext` in PG)
2. Query lifetime

This PR includes 4 parts:
1. Allocations within backend context.
2. Allocations within query context (plus support for protobuf string allocations within query context, uses `std::string_view` to allocate payloads outside protobuf).
3. Handling allocations with unknown lifetime (e.g., GUC reset).
(These objects are manually managed with explicit `palloc()`/`pfree()`)
4. Testing?

Important notes:
- When a memory context is deleted, it pfrees all its memory and child contexts. To properly destroy C++ objects, their destructors need to run before the memory is pfreed. PostgreSQL provides callbacks that run before freeing memory, and we use these to safely call destructors.
- By allocating memory in the right context, we usually don’t need to call `pfree()` manually. The memory context will free everything when it is deleted (Example of an exception is GUC-related allocations, which can be reset anytime during the backend’s lifetime).