### PR TITLE
Alloc mem using postgres memory contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 override CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-unused-but-set-variable -Wno-address -Wno-format-truncation -Wno-stringop-truncation -g -ggdb -std=gnu99 -Werror=uninitialized -Werror=implicit-function-declaration -DGPBUILD
-override CXXFLAGS = -fPIC -g3 -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-but-set-variable -Wno-address -Wno-format-truncation -Wno-stringop-truncation -g -ggdb -std=c++14 -Iinclude -Isrc/protos -Isrc -DGPBUILD
+override CXXFLAGS = -fPIC -g3 -Wall -Wpointer-arith -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-but-set-variable -Wno-address -Wno-format-truncation -Wno-stringop-truncation -g -ggdb -std=c++17 -Iinclude -Isrc/protos -Isrc -DGPBUILD
 COMMON_CPP_FLAGS := -Isrc -Iinclude -Isrc/stat_statements_parser
 PG_CXXFLAGS += $(COMMON_CPP_FLAGS)
 SHLIB_LINK += -lprotobuf -lpthread -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ OBJS			:=	$(PG_STAT_OBJS)						\
 					$(SRC_DIR)/UDSConnector.o			\
 					$(SRC_DIR)/EventSender.o 			\
 					$(SRC_DIR)/hook_wrappers.o		 	\
-					$(SRC_DIR)/yagp_hooks_collector.o
+					$(SRC_DIR)/yagp_hooks_collector.o   \
+					$(SRC_DIR)/memory/PgContext.o
 EXTRA_CLEAN     := $(GEN_DIR)
 DATA			:= $(wildcard sql/*--*.sql)
 EXTENSION		:= yagp_hooks_collector

--- a/protos/yagpcc_metrics.proto
+++ b/protos/yagpcc_metrics.proto
@@ -1,8 +1,11 @@
-syntax = "proto3";
+edition = "2023";
+
+import "google/protobuf/cpp_features.proto";
 
 package yagpcc;
 option java_outer_classname = "SegmentYAGPCCM";
 option go_package = "a.yandex-team.ru/cloud/mdb/yagpcc/api/proto/common;greenplum";
+option features.(pb.cpp).string_type=VIEW;
 
 enum QueryStatus {
     QUERY_STATUS_UNSPECIFIED = 0;

--- a/protos/yagpcc_plan.proto
+++ b/protos/yagpcc_plan.proto
@@ -1,8 +1,12 @@
-syntax = "proto3";
+edition = "2023";
+
+import "google/protobuf/cpp_features.proto";
 
 package yagpcc;
 option java_outer_classname = "SegmentYAGPCCP";
 option go_package = "a.yandex-team.ru/cloud/mdb/yagpcc/api/proto/common;greenplum";
+
+option features.(pb.cpp).string_type=VIEW;
 
 message MetricPlan {
     GpdbNodeType   type = 1;

--- a/protos/yagpcc_set_service.proto
+++ b/protos/yagpcc_set_service.proto
@@ -1,6 +1,7 @@
-syntax = "proto3";
+edition = "2023";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/cpp_features.proto";
 
 import "protos/yagpcc_metrics.proto";
 import "protos/yagpcc_plan.proto";
@@ -8,6 +9,7 @@ import "protos/yagpcc_plan.proto";
 package yagpcc;
 option java_outer_classname = "SegmentYAGPCCAS";
 option go_package = "a.yandex-team.ru/cloud/mdb/yagpcc/api/proto/agent_segment;greenplum";
+option features.(pb.cpp).string_type=VIEW;
 
 service SetQueryInfo {
     rpc SetMetricPlanNode (SetPlanNodeReq) returns (MetricResponse) {}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,7 +1,6 @@
 #include "Config.h"
 #include <limits.h>
 #include <memory>
-#include <string>
 #include <unordered_set>
 
 extern "C" {
@@ -119,11 +118,12 @@ size_t Config::max_text_size() { return guc_max_text_size * 1024; }
 size_t Config::max_plan_size() { return guc_max_plan_size * 1024; }
 int Config::min_analyze_time() { return guc_min_analyze_time; };
 
-bool Config::filter_user(const std::string *username) {
-  if (!username || !ignored_users_set) {
+bool Config::filter_user(std::string_view username) {
+  if (username.empty() || ignored_users_set == nullptr) {
     return true;
   }
-  return ignored_users_set->find(*username) != ignored_users_set->end();
+  return ignored_users_set->find(std::string(username)) !=
+         ignored_users_set->end();
 }
 
 void Config::sync() {

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,4 +1,6 @@
 #include "Config.h"
+#include "memory/PgContext.h"
+
 #include <limits.h>
 #include <memory>
 #include <unordered_set>
@@ -19,14 +21,16 @@ static int guc_max_text_size = 1024;  // in KB
 static int guc_max_plan_size = 1024;  // in KB
 static int guc_min_analyze_time = -1; // uninitialized state
 
-static std::unique_ptr<std::unordered_set<std::string>> ignored_users_set =
-    nullptr;
+using SetStrView = std::unordered_set<std::string_view>;
+
+static std::unique_ptr<SetStrView> ignored_users_set;
 static bool ignored_users_guc_dirty = false;
 
 static void update_ignored_users(const char *new_guc_ignored_users) {
-  auto new_ignored_users_set =
-      std::make_unique<std::unordered_set<std::string>>();
+  auto new_ignored_users_set = std::make_unique<SetStrView>();
   if (new_guc_ignored_users != nullptr && new_guc_ignored_users[0] != '\0') {
+    MemoryContext oldctx;
+    oldctx = MemoryContextSwitchTo(TopMemoryContext);
     /* Need a modifiable copy of string */
     char *rawstring = pstrdup(new_guc_ignored_users);
     List *elemlist;
@@ -37,6 +41,7 @@ static void update_ignored_users(const char *new_guc_ignored_users) {
       /* syntax error in list */
       pfree(rawstring);
       list_free(elemlist);
+      MemoryContextSwitchTo(oldctx);
       ereport(
           LOG,
           (errcode(ERRCODE_SYNTAX_ERROR),
@@ -45,10 +50,17 @@ static void update_ignored_users(const char *new_guc_ignored_users) {
       return;
     }
     foreach (l, elemlist) {
-      new_ignored_users_set->insert((char *)lfirst(l));
+      char *user = pstrdup((char *)lfirst(l));
+      new_ignored_users_set->emplace(user);
     }
     pfree(rawstring);
     list_free(elemlist);
+    MemoryContextSwitchTo(oldctx);
+  }
+  if (ignored_users_set) {
+    for (std::string_view user : *ignored_users_set) {
+      pfree(const_cast<char *>(user.data()));
+    }
   }
   ignored_users_set = std::move(new_ignored_users_set);
 }
@@ -109,7 +121,7 @@ void Config::init() {
       GUC_NOT_IN_SAMPLE | GUC_GPDB_NEED_SYNC | GUC_UNIT_MS, NULL, NULL, NULL);
 }
 
-std::string Config::uds_path() { return guc_uds_path; }
+std::string_view Config::uds_path() { return guc_uds_path; }
 bool Config::enable_analyze() { return guc_enable_analyze; }
 bool Config::enable_cdbstats() { return guc_enable_cdbstats; }
 bool Config::enable_collector() { return guc_enable_collector; }
@@ -122,8 +134,7 @@ bool Config::filter_user(std::string_view username) {
   if (username.empty() || ignored_users_set == nullptr) {
     return true;
   }
-  return ignored_users_set->find(std::string(username)) !=
-         ignored_users_set->end();
+  return ignored_users_set->find(username) != ignored_users_set->end();
 }
 
 void Config::sync() {

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 class Config {
 public:
@@ -9,7 +10,7 @@ public:
   static bool enable_analyze();
   static bool enable_cdbstats();
   static bool enable_collector();
-  static bool filter_user(const std::string *username);
+  static bool filter_user(std::string_view username);
   static bool report_nested_queries();
   static size_t max_text_size();
   static size_t max_plan_size();

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
 class Config {
 public:
   static void init();
-  static std::string uds_path();
+  static std::string_view uds_path();
   static bool enable_analyze();
   static bool enable_cdbstats();
   static bool enable_collector();

--- a/src/EventSender.cpp
+++ b/src/EventSender.cpp
@@ -20,6 +20,8 @@ extern "C" {
 #include "PgUtils.h"
 #include "ProtoUtils.h"
 
+extern ContextUniquePtr backend_context;
+
 #define need_collect_analyze()                                                 \
   (Gp_role == GP_ROLE_DISPATCH && Config::min_analyze_time() >= 0 &&           \
    Config::enable_analyze())
@@ -305,10 +307,11 @@ void EventSender::analyze_stats_collect(QueryDesc *query_desc) {
   }
 }
 
-EventSender::EventSender() {
+EventSender::EventSender()
+    : query_msgs(backend_context->get_allocator<QueryMapAllocator>()) {
   if (Config::enable_collector()) {
     try {
-      connector = new UDSConnector();
+      connector = backend_context->pnew<UDSConnector>();
     } catch (const std::exception &e) {
       ereport(INFO, (errmsg("Unable to start query tracing %s", e.what())));
     }
@@ -319,7 +322,6 @@ EventSender::EventSender() {
 }
 
 EventSender::~EventSender() {
-  delete connector;
   for (auto iter = query_msgs.begin(); iter != query_msgs.end(); ++iter) {
     delete iter->second.message;
   }

--- a/src/EventSender.cpp
+++ b/src/EventSender.cpp
@@ -20,6 +20,7 @@ extern "C" {
 #include "PgUtils.h"
 #include "ProtoUtils.h"
 
+extern ContextUniquePtr message_context;
 extern ContextUniquePtr backend_context;
 
 #define need_collect_analyze()                                                 \
@@ -29,6 +30,9 @@ extern ContextUniquePtr backend_context;
 void EventSender::query_metrics_collect(QueryMetricsStatus status, void *arg) {
   if (Gp_role != GP_ROLE_DISPATCH && Gp_role != GP_ROLE_EXECUTE) {
     return;
+  }
+  if (!message_context) {
+    message_context = ManagedMemContext::create_empty(MessageContext);
   }
   switch (status) {
   case METRICS_PLAN_NODE_INITIALIZE:
@@ -63,9 +67,13 @@ void EventSender::executor_before_start(QueryDesc *query_desc, int eflags) {
   if (!connector) {
     return;
   }
+  if (!message_context) {
+    message_context = ManagedMemContext::create_empty(MessageContext);
+  }
   if (is_top_level_query(query_desc, nesting_level)) {
     nested_timing = 0;
     nested_calls = 0;
+    query_msgs.clear();
   }
   Config::sync();
   if (!need_collect(query_desc, nesting_level)) {
@@ -128,6 +136,9 @@ void EventSender::executor_end(QueryDesc *query_desc) {
   if (!connector ||
       (Gp_role != GP_ROLE_DISPATCH && Gp_role != GP_ROLE_EXECUTE)) {
     return;
+  }
+  if (!message_context) {
+    message_context = ManagedMemContext::create_empty(MessageContext);
   }
   if (!filter_query(query_desc)) {
     auto *query = get_query_message(query_desc);
@@ -251,6 +262,9 @@ void EventSender::ic_metrics_collect() {
   if (Gp_interconnect_type != INTERCONNECT_TYPE_UDPIFC) {
     return;
   }
+  if (!message_context) {
+    message_context = ManagedMemContext::create_empty(MessageContext);
+  }
   if (!connector || gp_command_count == 0 || !Config::enable_collector() ||
       Config::filter_user(get_user_name())) {
     return;
@@ -282,6 +296,9 @@ void EventSender::ic_metrics_collect() {
 void EventSender::analyze_stats_collect(QueryDesc *query_desc) {
   if (!connector || Gp_role != GP_ROLE_DISPATCH) {
     return;
+  }
+  if (!message_context) {
+    message_context = ManagedMemContext::create_empty(MessageContext);
   }
   if (!need_collect(query_desc, nesting_level)) {
     return;
@@ -319,12 +336,6 @@ EventSender::EventSender()
 #ifdef IC_TEARDOWN_HOOK
   memset(&ic_statistics, 0, sizeof(ICStatistics));
 #endif
-}
-
-EventSender::~EventSender() {
-  for (auto iter = query_msgs.begin(); iter != query_msgs.end(); ++iter) {
-    delete iter->second.message;
-  }
 }
 
 // That's basically a very simplistic state machine to fix or highlight any bugs
@@ -366,11 +377,14 @@ EventSender::QueryItem *EventSender::get_query_message(QueryDesc *query_desc) {
       query_msgs.find({query_desc->gpmon_pkt->u.qexec.key.ccnt,
                        query_desc->gpmon_pkt->u.qexec.key.tmid}) ==
           query_msgs.end()) {
-    query_desc->gpmon_pkt = (gpmon_packet_t *)palloc0(sizeof(gpmon_packet_t));
+    query_desc->gpmon_pkt =
+        message_context->allocate0<gpmon_packet_t>(sizeof(gpmon_packet_t));
     query_desc->gpmon_pkt->u.qexec.key.ccnt = gp_command_count;
     query_desc->gpmon_pkt->u.qexec.key.tmid = nesting_level;
-    query_msgs.insert({{gp_command_count, nesting_level},
-                       QueryItem(UNKNOWN, new yagpcc::SetQueryReq())});
+    query_msgs.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(gp_command_count, nesting_level),
+        std::forward_as_tuple(message_context->pnew<yagpcc::SetQueryReq>()));
   }
   return &query_msgs.at({query_desc->gpmon_pkt->u.qexec.key.ccnt,
                          query_desc->gpmon_pkt->u.qexec.key.tmid});
@@ -393,6 +407,4 @@ void EventSender::update_nested_counters(QueryDesc *query_desc) {
   }
 }
 
-EventSender::QueryItem::QueryItem(EventSender::QueryState st,
-                                  yagpcc::SetQueryReq *msg)
-    : state(st), message(msg) {}
+EventSender::QueryItem::QueryItem(yagpcc::SetQueryReq *msg) : message(msg) {}

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "memory/PgContext.h"
+
 #include <memory>
 #include <unordered_map>
 #include <string>
@@ -43,14 +45,6 @@ private:
     QueryItem(QueryState st, yagpcc::SetQueryReq *msg);
   };
 
-  struct pair_hash {
-    std::size_t operator()(const std::pair<int, int> &p) const {
-      auto h1 = std::hash<int>{}(p.first);
-      auto h2 = std::hash<int>{}(p.second);
-      return h1 ^ h2;
-    }
-  };
-
   void update_query_state(QueryDesc *query_desc, QueryItem *query,
                           QueryState new_state, bool success = true);
   QueryItem *get_query_message(QueryDesc *query_desc);
@@ -66,5 +60,18 @@ private:
 #ifdef IC_TEARDOWN_HOOK
   ICStatistics ic_statistics;
 #endif
-  std::unordered_map<std::pair<int, int>, QueryItem, pair_hash> query_msgs;
+  using QueryKey = std::pair<int, int>;
+  using QueryValue = QueryItem;
+  using QueryMapAllocator =
+      PallocZeroAllocator<std::pair<const QueryKey, QueryValue>>;
+  struct pair_hash {
+    std::size_t operator()(const QueryKey &p) const {
+      auto h1 = std::hash<int>{}(p.first);
+      auto h2 = std::hash<int>{}(p.second);
+      return h1 ^ h2;
+    }
+  };
+  std::unordered_map<QueryKey, QueryValue, pair_hash, std::equal_to<QueryKey>,
+                     QueryMapAllocator>
+      query_msgs;
 };

--- a/src/EventSender.h
+++ b/src/EventSender.h
@@ -33,7 +33,6 @@ public:
   void incr_depth() { nesting_level++; }
   void decr_depth() { nesting_level--; }
   EventSender();
-  ~EventSender();
 
 private:
   enum QueryState { UNKNOWN, SUBMIT, START, END, DONE };
@@ -42,7 +41,7 @@ private:
     QueryState state = QueryState::UNKNOWN;
     yagpcc::SetQueryReq *message = nullptr;
 
-    QueryItem(QueryState st, yagpcc::SetQueryReq *msg);
+    QueryItem(yagpcc::SetQueryReq *msg);
   };
 
   void update_query_state(QueryDesc *query_desc, QueryItem *query,

--- a/src/PgUtils.cpp
+++ b/src/PgUtils.cpp
@@ -3,35 +3,38 @@
 
 extern "C" {
 #include "utils/guc.h"
+#include "utils/memutils.h"
 #include "commands/dbcommands.h"
 #include "commands/resgroupcmds.h"
 #include "cdb/cdbvars.h"
 }
 
-std::string *get_user_name() {
+std::string_view get_user_name() {
   const char *username = GetConfigOption("session_authorization", false, false);
-  // username is not to be freed
-  return username ? new std::string(username) : nullptr;
+  // Allocate username per message context as it can be changed in the next
+  // query.
+  return username ? MemoryContextStrdup(MessageContext, username)
+                  : std::string_view();
 }
 
-std::string *get_db_name() {
+std::string_view get_db_name() {
+  // Switch to the context since get_database_name() returns a palloc'd string.
+  MemoryContext oldctx = MemoryContextSwitchTo(MessageContext);
   char *dbname = get_database_name(MyDatabaseId);
-  std::string *result = nullptr;
-  if (dbname) {
-    result = new std::string(dbname);
-    pfree(dbname);
-  }
-  return result;
+  MemoryContextSwitchTo(oldctx);
+  return dbname ? dbname : std::string_view();
 }
 
-std::string *get_rg_name() {
+std::string_view get_rg_name() {
   auto groupId = ResGroupGetGroupIdBySessionId(MySessionState->sessionId);
   if (!OidIsValid(groupId))
-    return nullptr;
+    return {};
+  // Switch to the context since GetResGroupNameForId() returns a palloc'd
+  // string.
+  MemoryContext oldctx = MemoryContextSwitchTo(MessageContext);
   char *rgname = GetResGroupNameForId(groupId);
-  if (rgname == nullptr)
-    return nullptr;
-  return new std::string(rgname);
+  MemoryContextSwitchTo(oldctx);
+  return rgname ? rgname : std::string_view();
 }
 
 /**

--- a/src/PgUtils.h
+++ b/src/PgUtils.h
@@ -3,11 +3,11 @@ extern "C" {
 #include "commands/explain.h"
 }
 
-#include <string>
+#include <string_view>
 
-std::string *get_user_name();
-std::string *get_db_name();
-std::string *get_rg_name();
+std::string_view get_user_name();
+std::string_view get_db_name();
+std::string_view get_rg_name();
 bool is_top_level_query(QueryDesc *query_desc, int nesting_level);
 bool nesting_is_valid(QueryDesc *query_desc, int nesting_level);
 bool need_report_nested_query();

--- a/src/ProtoUtils.cpp
+++ b/src/ProtoUtils.cpp
@@ -2,6 +2,7 @@
 #include "PgUtils.h"
 #include "ProcStats.h"
 #include "Config.h"
+#include "memory/PgContext.h"
 
 #define typeid __typeid
 #define operator __operator
@@ -24,7 +25,7 @@ extern "C" {
 #undef operator
 
 #include <ctime>
-#include <string>
+#include <string_view>
 
 google::protobuf::Timestamp current_ts() {
   google::protobuf::Timestamp current_ts;
@@ -48,9 +49,9 @@ void set_segment_key(yagpcc::SegmentKey *key) {
   key->set_segindex(GpIdentity.segindex);
 }
 
-inline std::string char_to_trimmed_str(const char *str, size_t len,
-                                       size_t lim) {
-  return std::string(str, std::min(len, lim));
+inline std::string_view char_to_trimmed_str(const char *str, size_t len,
+                                            size_t lim) {
+  return std::string_view(str, std::min(len, lim));
 }
 
 void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
@@ -59,31 +60,28 @@ void set_query_plan(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
     qi->set_generator(query_desc->plannedstmt->planGen == PLANGEN_OPTIMIZER
                           ? yagpcc::PlanGenerator::PLAN_GENERATOR_OPTIMIZER
                           : yagpcc::PlanGenerator::PLAN_GENERATOR_PLANNER);
-    MemoryContext oldcxt =
-        MemoryContextSwitchTo(query_desc->estate->es_query_cxt);
+    MemoryContext oldcxt = MemoryContextSwitchTo(MessageContext);
     auto es = get_explain_state(query_desc, true);
-    MemoryContextSwitchTo(oldcxt);
-    *qi->mutable_plan_text() =
-        char_to_trimmed_str(es.str->data, es.str->len, Config::max_plan_size());
+    qi->set_plan_text(char_to_trimmed_str(es.str->data, es.str->len,
+                                          Config::max_plan_size()));
     StringInfo norm_plan = gen_normplan(es.str->data);
-    *qi->mutable_template_plan_text() = char_to_trimmed_str(
-        norm_plan->data, norm_plan->len, Config::max_plan_size());
+    MemoryContextSwitchTo(oldcxt);
+    qi->set_template_plan_text(char_to_trimmed_str(
+        norm_plan->data, norm_plan->len, Config::max_plan_size()));
     qi->set_plan_id(hash_any((unsigned char *)norm_plan->data, norm_plan->len));
     qi->set_query_id(query_desc->plannedstmt->queryId);
-    pfree(es.str->data);
-    pfree(norm_plan->data);
   }
 }
 
 void set_query_text(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
   if (Gp_session_role == GP_ROLE_DISPATCH && query_desc->sourceText) {
     auto qi = req->mutable_query_info();
-    *qi->mutable_query_text() = char_to_trimmed_str(
-        query_desc->sourceText, strlen(query_desc->sourceText),
-        Config::max_text_size());
+    qi->set_query_text(char_to_trimmed_str(query_desc->sourceText,
+                                           strlen(query_desc->sourceText),
+                                           Config::max_text_size()));
     char *norm_query = gen_normquery(query_desc->sourceText);
-    *qi->mutable_template_query_text() = char_to_trimmed_str(
-        norm_query, strlen(norm_query), Config::max_text_size());
+    qi->set_template_query_text(char_to_trimmed_str(
+        norm_query, strlen(norm_query), Config::max_text_size()));
   }
 }
 
@@ -122,8 +120,8 @@ void set_qi_slice_id(yagpcc::SetQueryReq *req) {
 void set_qi_error_message(yagpcc::SetQueryReq *req) {
   auto aqi = req->mutable_add_info();
   auto error = elog_message();
-  *aqi->mutable_error_message() =
-      char_to_trimmed_str(error, strlen(error), Config::max_text_size());
+  aqi->set_error_message(
+      char_to_trimmed_str(error, strlen(error), Config::max_text_size()));
 }
 
 void set_metric_instrumentation(yagpcc::MetricInstrumentation *metrics,
@@ -234,11 +232,13 @@ void set_analyze_plan_text_json(QueryDesc *query_desc,
   if (!IsTransactionState() || !query_desc->plannedstmt) {
     return;
   }
-  MemoryContext oldcxt =
-      MemoryContextSwitchTo(query_desc->estate->es_query_cxt);
+  // Allocate analyze state in MessageContext so it stays alive up to the
+  // sending point.
+  MemoryContext oldcxt = MemoryContextSwitchTo(MessageContext);
 
   ExplainState es = get_analyze_state_json(
       query_desc, query_desc->instrument_options && Config::enable_analyze());
+  MemoryContextSwitchTo(oldcxt);
   // Remove last line break.
   if (es.str->len > 0 && es.str->data[es.str->len - 1] == '\n') {
     es.str->data[--es.str->len] = '\0';
@@ -251,7 +251,4 @@ void set_analyze_plan_text_json(QueryDesc *query_desc,
   auto trimmed_analyze =
       char_to_trimmed_str(es.str->data, es.str->len, Config::max_plan_size());
   req->mutable_query_info()->set_analyze_text(trimmed_analyze);
-
-  pfree(es.str->data);
-  MemoryContextSwitchTo(oldcxt);
 }

--- a/src/ProtoUtils.cpp
+++ b/src/ProtoUtils.cpp
@@ -79,7 +79,9 @@ void set_query_text(yagpcc::SetQueryReq *req, QueryDesc *query_desc) {
     qi->set_query_text(char_to_trimmed_str(query_desc->sourceText,
                                            strlen(query_desc->sourceText),
                                            Config::max_text_size()));
+    MemoryContext oldcxt = MemoryContextSwitchTo(MessageContext);
     char *norm_query = gen_normquery(query_desc->sourceText);
+    MemoryContextSwitchTo(oldcxt);
     qi->set_template_query_text(char_to_trimmed_str(
         norm_query, strlen(norm_query), Config::max_text_size()));
   }

--- a/src/ProtoUtils.cpp
+++ b/src/ProtoUtils.cpp
@@ -101,11 +101,11 @@ void clear_big_fields(yagpcc::SetQueryReq *req) {
 void set_query_info(yagpcc::SetQueryReq *req) {
   if (Gp_session_role == GP_ROLE_DISPATCH) {
     auto qi = req->mutable_query_info();
-    qi->set_allocated_username(get_user_name());
+    qi->set_username(get_user_name());
     if (IsTransactionState()) {
-      qi->set_allocated_databasename(get_db_name());
+      qi->set_databasename(get_db_name());
     }
-    qi->set_allocated_rsgname(get_rg_name());
+    qi->set_rsgname(get_rg_name());
   }
 }
 

--- a/src/ProtoUtils.cpp
+++ b/src/ProtoUtils.cpp
@@ -102,7 +102,9 @@ void set_query_info(yagpcc::SetQueryReq *req) {
   if (Gp_session_role == GP_ROLE_DISPATCH) {
     auto qi = req->mutable_query_info();
     qi->set_allocated_username(get_user_name());
-    qi->set_allocated_databasename(get_db_name());
+    if (IsTransactionState()) {
+      qi->set_allocated_databasename(get_db_name());
+    }
     qi->set_allocated_rsgname(get_rg_name());
   }
 }

--- a/src/UDSConnector.cpp
+++ b/src/UDSConnector.cpp
@@ -30,13 +30,13 @@ bool UDSConnector::report_query(const yagpcc::SetQueryReq &req,
                                 const std::string &event) {
   sockaddr_un address;
   address.sun_family = AF_UNIX;
-  std::string uds_path = Config::uds_path();
+  std::string_view uds_path = Config::uds_path();
   if (uds_path.size() >= sizeof(address.sun_path)) {
     ereport(WARNING, (errmsg("UDS path is too long for socket buffer")));
     YagpStat::report_error();
     return false;
   }
-  strcpy(address.sun_path, uds_path.c_str());
+  strcpy(address.sun_path, uds_path.data());
   bool success = true;
   auto sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sockfd != -1) {

--- a/src/hook_wrappers.cpp
+++ b/src/hook_wrappers.cpp
@@ -46,6 +46,7 @@ static void ya_ic_teardown_hook(ChunkTransportState *transportStates,
 static void ya_analyze_stats_collect_hook(QueryDesc *query_desc);
 #endif
 
+ContextUniquePtr message_context;
 ContextUniquePtr backend_context;
 // Owned by the backend_context.
 static EventSender *sender = nullptr;
@@ -106,6 +107,7 @@ void hooks_deinit() {
 #endif
   stat_statements_parser_deinit();
   YagpStat::deinit();
+  message_context.reset();
   backend_context.reset();
   sender = nullptr;
 }

--- a/src/hook_wrappers.cpp
+++ b/src/hook_wrappers.cpp
@@ -17,6 +17,7 @@ extern "C" {
 #include "Config.h"
 #include "YagpStat.h"
 #include "EventSender.h"
+#include "memory/PgContext.h"
 #include "hook_wrappers.h"
 #include "stat_statements_parser/pg_stat_statements_ya_parser.h"
 
@@ -45,11 +46,14 @@ static void ya_ic_teardown_hook(ChunkTransportState *transportStates,
 static void ya_analyze_stats_collect_hook(QueryDesc *query_desc);
 #endif
 
+ContextUniquePtr backend_context;
+// Owned by the backend_context.
 static EventSender *sender = nullptr;
 
 static inline EventSender *get_sender() {
   if (!sender) {
-    sender = new EventSender();
+    Assert(backend_context);
+    sender = backend_context->pnew<EventSender>();
   }
   return sender;
 }
@@ -85,6 +89,7 @@ void hooks_init() {
   analyze_stats_collect_hook = ya_analyze_stats_collect_hook;
 #endif
   stat_statements_parser_init();
+  backend_context = ManagedMemContext::create_empty(TopMemoryContext);
 }
 
 void hooks_deinit() {
@@ -100,10 +105,9 @@ void hooks_deinit() {
   analyze_stats_collect_hook = previous_analyze_stats_collect_hook;
 #endif
   stat_statements_parser_deinit();
-  if (sender) {
-    delete sender;
-  }
   YagpStat::deinit();
+  backend_context.reset();
+  sender = nullptr;
 }
 
 void ya_ExecutorStart_hook(QueryDesc *query_desc, int eflags) {

--- a/src/memory/PgContext.cpp
+++ b/src/memory/PgContext.cpp
@@ -1,0 +1,62 @@
+#include "PgContext.h"
+
+#include <stdexcept>
+#include <type_traits>
+
+ManagedMemContext::ManagedMemContext(MemoryContext ctx) : ctx_alloc(ctx) {}
+
+ManagedMemContext::~ManagedMemContext() {
+  ctx_alloc = nullptr;
+  dtor_thunks = nullptr;
+}
+
+ContextUniquePtr ManagedMemContext::create_empty(MemoryContext ctx_alloc,
+                                                 MemoryContext ctx_manager) {
+  void *mem = MemoryContextAllocZero(ctx_manager, sizeof(ManagedMemContext));
+  ManagedMemContext *obj = new (mem) ManagedMemContext(ctx_alloc);
+  return ContextUniquePtr(obj);
+}
+
+void ManagedMemContext::init() {
+  if (!MemoryContextIsValid(ctx_alloc)) {
+    throw std::runtime_error(
+        "Can not init ManagedMemContext with invalid PG context.");
+  }
+  // Allocate the vector itself inside the ctx_alloc.
+  PallocZeroAllocator<DtorThunk> allocator(ctx_alloc);
+  void *vec_mem = MemoryContextAlloc(
+      ctx_alloc,
+      sizeof(std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>));
+  dtor_thunks = new (vec_mem)
+      std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>(allocator);
+  // Register a callback so PG's MemoryContext Reset/Delete will call our dtors.
+  context_callback.func = ManagedMemContext::reset_callback;
+  context_callback.arg = this;
+  MemoryContextRegisterResetCallback(ctx_alloc, &context_callback);
+  reset = false;
+}
+
+void ManagedMemContext::run_destructors() {
+  // Call destructors in reverse order of construction.
+  for (auto it = dtor_thunks->rbegin(); it != dtor_thunks->rend(); ++it) {
+    (*it)();
+  }
+  // The vector's memory will be freed by the subsequent MemoryContext
+  // Reset/Delete, so we don't need to clear it here. Just call its own
+  // destructor.
+  dtor_thunks->~vector();
+}
+
+void ManagedMemContext::reset_callback(void *arg) {
+  auto self = static_cast<ManagedMemContext *>(arg);
+  self->run_destructors();
+  self->dtor_thunks = nullptr;
+  self->reset = true;
+}
+
+void PallocDeleter::operator()(ManagedMemContext *p) const {
+  if (p) {
+    p->~ManagedMemContext();
+    pfree(p);
+  }
+}

--- a/src/memory/PgContext.cpp
+++ b/src/memory/PgContext.cpp
@@ -13,7 +13,7 @@ ManagedMemContext::~ManagedMemContext() {
 ContextUniquePtr ManagedMemContext::create_empty(MemoryContext ctx_alloc,
                                                  MemoryContext ctx_manager) {
   void *mem = MemoryContextAllocZero(ctx_manager, sizeof(ManagedMemContext));
-  ManagedMemContext *obj = new (mem) ManagedMemContext(ctx_alloc);
+  auto obj = construct_at<ManagedMemContext>(mem, ctx_alloc);
   return ContextUniquePtr(obj);
 }
 
@@ -24,11 +24,8 @@ void ManagedMemContext::init() {
   }
   // Allocate the vector itself inside the ctx_alloc.
   PallocZeroAllocator<DtorThunk> allocator(ctx_alloc);
-  void *vec_mem = MemoryContextAlloc(
-      ctx_alloc,
-      sizeof(std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>));
-  dtor_thunks = new (vec_mem)
-      std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>(allocator);
+  void *vec_mem = MemoryContextAlloc(ctx_alloc, sizeof(DtorThunks));
+  dtor_thunks = construct_at<DtorThunks>(vec_mem, allocator);
   // Register a callback so PG's MemoryContext Reset/Delete will call our dtors.
   context_callback.func = ManagedMemContext::reset_callback;
   context_callback.arg = this;

--- a/src/memory/PgContext.h
+++ b/src/memory/PgContext.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <new>
+#include <vector>
+#include <memory>
+#include <functional>
+
+extern "C" {
+#include "postgres.h"
+#include "utils/memutils.h"
+}
+
+template <typename T> struct PallocZeroAllocator {
+  using value_type = T;
+  MemoryContext context;
+
+  explicit PallocZeroAllocator(MemoryContext ctx) noexcept : context(ctx) {}
+
+  template <class U>
+  PallocZeroAllocator(const PallocZeroAllocator<U> &other) noexcept
+      : context(other.context) {}
+
+  template <typename U> struct rebind { using other = PallocZeroAllocator<U>; };
+
+  T *allocate(size_t n) {
+    return static_cast<T *>(MemoryContextAllocZero(context, n * sizeof(T)));
+  }
+
+  void deallocate(T *p, size_t) { pfree(p); }
+};
+
+template <class T, class U>
+bool operator==(const PallocZeroAllocator<T> &a,
+                const PallocZeroAllocator<U> &b) noexcept {
+  return a.context == b.context;
+}
+
+template <class T, class U>
+bool operator!=(const PallocZeroAllocator<T> &a,
+                const PallocZeroAllocator<U> &b) noexcept {
+  return !(a == b);
+}
+
+class ManagedMemContext;
+
+struct PallocDeleter {
+  void operator()(ManagedMemContext *p) const;
+};
+
+using ContextUniquePtr = std::unique_ptr<ManagedMemContext, PallocDeleter>;
+
+// Manages the lifetime of a PG MemoryContext and handles the
+// destruction of C++ objects allocated within it.
+class ManagedMemContext {
+  friend struct PallocDeleter;
+
+public:
+  using DtorThunk = std::function<void()>;
+
+  static ContextUniquePtr
+  create_empty(MemoryContext ctx_alloc,
+               MemoryContext ctx_manager = TopMemoryContext);
+
+  ManagedMemContext(const ManagedMemContext &) = delete;
+  ManagedMemContext &operator=(const ManagedMemContext &) = delete;
+
+  // Constructs an object within the context.
+  // Its destructor will be called when the context is reset or destroyed.
+  template <typename T, typename... Args> T *pnew(Args &&...args) {
+    // Double-check that the destructor does not throw because it is called in
+    // PG code.
+    static_assert(std::is_nothrow_destructible_v<T>,
+                  "Types allocated in a ManagedMemContext must have a noexcept "
+                  "destructor");
+    // We do not own the ctx_alloc, it can be reset or deleted any time,
+    // reinit if the context was reset.
+    if (reset) {
+      init();
+    }
+    T *obj = new (allocate0<T>(sizeof(T))) T(std::forward<Args>(args)...);
+    // Register the destructor to be called on cleanup.
+    DtorThunk dtor = [obj]() { obj->~T(); };
+    dtor_thunks->push_back(std::move(dtor));
+    return obj;
+  }
+
+  template <typename T> PallocZeroAllocator<T> get_allocator() const {
+    return PallocZeroAllocator<T>(ctx_alloc);
+  }
+
+  MemoryContext get_context() const { return ctx_alloc; }
+
+  // Allocate raw, zero initialized memory within the context.
+  template <typename T = void> T *allocate0(size_t size) {
+    return static_cast<T *>(MemoryContextAllocZero(ctx_alloc, size));
+  }
+
+private:
+  ManagedMemContext(MemoryContext ctx);
+  ~ManagedMemContext();
+
+  void init();
+  void run_destructors();
+  static void reset_callback(void *arg);
+
+  MemoryContext ctx_alloc = nullptr;
+  bool reset = true;
+  MemoryContextCallback context_callback = {0};
+  // Holds the destructors. It is itself allocated within the context.
+  std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>> *dtor_thunks = nullptr;
+};

--- a/src/memory/PgContext.h
+++ b/src/memory/PgContext.h
@@ -77,7 +77,8 @@ public:
     if (reset) {
       init();
     }
-    T *obj = new (allocate0<T>(sizeof(T))) T(std::forward<Args>(args)...);
+    void *mem = allocate0(sizeof(T));
+    T *obj = construct_at<T>(mem, std::forward<Args>(args)...);
     // Register the destructor to be called on cleanup.
     DtorThunk dtor = [obj]() { obj->~T(); };
     dtor_thunks->push_back(std::move(dtor));
@@ -96,6 +97,16 @@ public:
   }
 
 private:
+  template <typename T, typename... Args>
+  static T *construct_at(void *mem, Args &&...args) {
+    try {
+      return new (mem) T(std::forward<Args>(args)...);
+    } catch (...) {
+      pfree(mem);
+      throw;
+    }
+  }
+
   ManagedMemContext(MemoryContext ctx);
   ~ManagedMemContext();
 
@@ -106,6 +117,7 @@ private:
   MemoryContext ctx_alloc = nullptr;
   bool reset = true;
   MemoryContextCallback context_callback = {0};
+  using DtorThunks = std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>>;
   // Holds the destructors. It is itself allocated within the context.
-  std::vector<DtorThunk, PallocZeroAllocator<DtorThunk>> *dtor_thunks = nullptr;
+  DtorThunks *dtor_thunks = nullptr;
 };


### PR DESCRIPTION
This pr replaces heap allocations with postgres memory context allocations (e.g., `palloc()` / `pfree()`).

All heap allocations in the extension fall into two groups based on their lifetimes:
1. Backend lifetime (`TopMemoryContext` in pg).
2. Query lifetime, from user perspective (`MessageContext` in pg).

Important notes:
- When a memory context is deleted, it pfrees all its memory and deletes child contexts. To properly destroy C++ objects, their destructors need to run before the memory is pfreed. PostgreSQL provides callbacks that run before freeing memory, and we use these to safely call noexcept destructors.
- By allocating memory in the right context, we usually don’t need to call `pfree()` manually. The memory context will free everything when it is deleted or reset.